### PR TITLE
Add retry to travis image push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,11 @@ jobs:
         - provider: script
           on:  # yamllint disable-line rule:truthy
             branch: master
-          script: .travis/push_container.sh "${WORKLOAD_REPO}" verbatim latest
+          script: travis_retry .travis/push_container.sh "${WORKLOAD_REPO}" verbatim latest
         # Tags of the form v + SEMVER (e.g., v1.2.3) will push to the
         # corresponding container version number (e.g., :1.2.3).
         - provider: script
           on:  # yamllint disable-line rule:truthy
             tags: true
             condition: $TRAVIS_TAG =~ ^v[0-9]+
-          script: .travis/push_container.sh "${WORKLOAD_REPO}" version "$TRAVIS_TAG"
+          script: travis_retry .travis/push_container.sh "${WORKLOAD_REPO}" version "$TRAVIS_TAG"


### PR DESCRIPTION
Image push, like any other network operation in Travis, has a tendency to fail randomly. This adds a retry.