### PR TITLE
Revert "Add retry to travis image push"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,11 @@ jobs:
         - provider: script
           on:  # yamllint disable-line rule:truthy
             branch: master
-          script: travis_retry .travis/push_container.sh "${WORKLOAD_REPO}" verbatim latest
+          script: .travis/push_container.sh "${WORKLOAD_REPO}" verbatim latest
         # Tags of the form v + SEMVER (e.g., v1.2.3) will push to the
         # corresponding container version number (e.g., :1.2.3).
         - provider: script
           on:  # yamllint disable-line rule:truthy
             tags: true
             condition: $TRAVIS_TAG =~ ^v[0-9]+
-          script: travis_retry .travis/push_container.sh "${WORKLOAD_REPO}" version "$TRAVIS_TAG"
+          script: .travis/push_container.sh "${WORKLOAD_REPO}" version "$TRAVIS_TAG"


### PR DESCRIPTION
Reverts JohnStrunk/ocs-monkey#15

It appears that `travis_retry` isn't available in the deploy stage