### PR TITLE
Make generator "resumable"

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -114,6 +114,7 @@ def main() -> None:
     kube.create_namespace(CLI_ARGS.namespace, existing_ok=True)
 
     dispatch = event.Dispatcher()
+    dispatch.add(*osio.resume(CLI_ARGS.namespace))
     dispatch.add(osio.start(namespace=CLI_ARGS.namespace,
                             storage_class=CLI_ARGS.storageclass,
                             access_mode=CLI_ARGS.accessmode,


### PR DESCRIPTION
When the generator is (re)started, it looks for Deployments in the
requested namespace that have the ocs-monkey/controller=osio label,
meaning they were started by this generator. For each one it finds, it
schedules a Lifecycle event to resume managing it.

This functionality was added in preparation for running the generator in
the OCP cluster, where it must withstand disruptions/restarts.

Fixes #4 