### PR TITLE
Monitor pod start & stop times

### DIFF
--- a/osio.py
+++ b/osio.py
@@ -11,17 +11,21 @@ task of the Lifecycle event is to destroy the workload's resources.
 """
 
 
+import concurrent.futures
+import copy
 import logging
 import random
 import time
 from typing import Any, Callable, Dict, List  # pylint: disable=unused-import
 
+import kubernetes
 import kubernetes.client as k8s
 
 import kube
 from event import Event
 
 LOGGER = logging.getLogger(__name__)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=20)
 
 class UnhealthyDeployment(Exception):
     """Exception raised when a workload instance fails its health check.
@@ -117,6 +121,32 @@ def resume(namespace: str) -> List[Event]:
                                 name=deployment["metadata"]["name"]))
     return events
 
+def _pod_start_watcher(deployment: kube.MANIFEST) -> None:
+    selector = deployment["spec"]["selector"]
+    if "matchLabels" in selector:  # when created as a dict
+        did = selector["matchLabels"]["deployment-id"]
+    else:  # when object converted to dict
+        did = selector["match_labels"]["deployment-id"]
+    label = f'deployment-id={did}'
+    LOGGER.debug("watcher for %s", label)
+    start_time = time.time()
+    watch = kubernetes.watch.Watch()
+    core_v1 = k8s.CoreV1Api()
+    for event in watch.stream(
+            func=core_v1.list_namespaced_pod,
+            namespace=deployment["metadata"]["namespace"],
+            label_selector=label):
+        if event["object"].status.phase == "Running":
+            watch.stop()
+            end_time = time.time()
+            d_name = f'{deployment["metadata"]["namespace"]}/{deployment["metadata"]["name"]}'
+            LOGGER.info("%s started in %0.2f sec", d_name, end_time-start_time)
+        # event.type: ADDED, MODIFIED, DELETED
+        if event["type"] == "DELETED":
+            # Pod was deleted while we were waiting for it to start.
+            LOGGER.debug("%s deleted before it started", did)
+            watch.stop()
+
 def _get_workload(ns_name: str,
                   sc_name: str,
                   access_mode: str) -> Dict[str, kube.MANIFEST]:
@@ -154,7 +184,11 @@ def _get_workload(ns_name: str,
                     "containers": [{
                         "name": "osio-workload",
                         "image": "quay.io/johnstrunk/osio-workload",
-                        "args": ["--untar-rate", "10", "--rm-rate", "10"],
+                        "args": [
+                            "--untar-rate", "10",
+                            "--rm-rate", "10",
+                            "--kernel-slots", "3"
+                        ],
                         "readinessProbe": {
                             "exec": {
                                 "command": ["/health.sh"]
@@ -266,6 +300,7 @@ class Creator(Event):
         kube.call(apps_v1.create_namespaced_deployment,
                   namespace=deploy["metadata"]["namespace"],
                   body=deploy)
+        EXECUTOR.submit(_pod_start_watcher, deploy)
         return [
             Lifecycle(when=0,  # execute asap
                       namespace=deploy["metadata"]["namespace"],
@@ -284,7 +319,7 @@ class Lifecycle(Event):
     """Manage the lifecycle of a workload instance."""
 
     _health_interval = 10  # When already running
-    _health_interval_initial = 60  # When pod starting
+    _health_interval_initial = 300  # When pod starting
 
     def __init__(self, when: float, namespace: str, name: str) -> None:
         """
@@ -352,6 +387,7 @@ class Lifecycle(Event):
             idle_time = time.time() + random.expovariate(1/active_mean)
             health_time = time.time() + self._health_interval_initial
             LOGGER.info("idle->active: %s/%s", self._namespace, self._name)
+            EXECUTOR.submit(_pod_start_watcher, copy.deepcopy(deploy))
         else:  # active -> idle
             deploy["spec"]["replicas"] = 0
             idle_mean = float(anno["ocs-monkey/osio-idle"])


### PR DESCRIPTION
This spawns threads to track pod startup and termination time. The threads establish a watch on the label selector for the deployment and log when the matching pod is either "running" or is deleted.

There is a known race wherein the label selector could map to either multiple pods if the deployment is scaled rapidly. It is also possible to miss the delete event if kube is too quick at tearing down the pod. I don't currently have a good solution for these.

Fixes #13, #21